### PR TITLE
feat(realtime): add per-channel SSE endpoints for the bundled SPA

### DIFF
--- a/frontend.go
+++ b/frontend.go
@@ -53,20 +53,52 @@ func (f *Frontend) Mount(mux *http.ServeMux) {
 
 // handleSPA serves embedded static assets and falls back to index.html for
 // any path the SPA owns (client-side routing).
+//
+// HEAD-method note: the bundled SPA opens EventSource (Server-Sent Events)
+// channels for live block / token / tx streams and pre-flights each URL
+// with a HEAD request:
+//
+//	fetch(url, {method: 'HEAD'}).then(r => r.ok ? openEventSource() : disable());
+//
+// If we serve a 200 (because of the SPA fallback to index.html), the SPA
+// proceeds to open the EventSource — which then immediately aborts because
+// the response body is text/html, not text/event-stream. Browser logs
+// "EventSource's response has a MIME type ('text/html') that is not
+// 'text/event-stream'" for every channel on every page load — noisy and
+// disables the channel anyway.
+//
+// Fix: return 404 for HEAD requests on the SPA-fallback path. Real assets
+// (anything in `f.root`) still serve normally on HEAD; only the index.html
+// fallback gets the 404 so the SSE pre-flight cleanly fails and the SPA
+// disables that channel on its own. Visible browser load is unchanged
+// because the SPA only HEAD-probes its SSE endpoints, never the SPA URL
+// itself.
 func (f *Frontend) handleSPA(w http.ResponseWriter, r *http.Request) {
 	p := strings.TrimPrefix(r.URL.Path, "/")
 	if p == "" {
+		if r.Method == http.MethodHead {
+			http.NotFound(w, r)
+			return
+		}
 		f.writeIndex(w)
 		return
 	}
 	file, err := f.root.Open(p)
 	if err != nil {
+		if r.Method == http.MethodHead {
+			http.NotFound(w, r)
+			return
+		}
 		f.writeIndex(w)
 		return
 	}
 	defer file.Close()
 	stat, err := file.Stat()
 	if err != nil || stat.IsDir() {
+		if r.Method == http.MethodHead {
+			http.NotFound(w, r)
+			return
+		}
 		f.writeIndex(w)
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -141,6 +141,28 @@ func main() {
 		json.NewEncoder(w).Encode(registry.hub.Stats())
 	})
 
+	// SSE endpoints at the URLs the bundled SPA opens EventSource on.
+	// See realtime_sse.go for the channel mapping + the back-story on
+	// why each path needs its own handler. Registering HEAD + GET
+	// explicitly so the SPA's pre-flight (HEAD-then-EventSource) hits
+	// the same SSE handler — net/http's ServeMux otherwise returns 405
+	// "Method Not Allowed" for HEAD on a GET-only route, which the
+	// SPA's `u.ok` check would reject and disable the channel.
+	for path, channel := range map[string]string{
+		"/blocks":          "blocks",
+		"/transactions":    "transactions",
+		"/token-transfers": "token_transfers",
+		"/internal-txs":    "internal_transactions",
+		"/tokens":          "tokens",
+		"/gas-tracker":     "gas_tracker",
+		"/validators":      "validators",
+		"/stats":           "stats",
+	} {
+		h := registry.hub.HandleSSE(channel)
+		mux.HandleFunc("GET "+path, h)
+		mux.HandleFunc("HEAD "+path, h)
+	}
+
 	supervisor.MountRoutes(mux)
 	frontend.Mount(mux)
 

--- a/realtime.go
+++ b/realtime.go
@@ -11,10 +11,15 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-// RealtimeHub manages multi-chain WebSocket subscriptions.
+// RealtimeHub manages multi-chain WebSocket subscriptions, plus a
+// parallel set of SSE subscribers (see realtime_sse.go) so the bundled
+// SPA — which opens EventSource against /blocks, /transactions, etc.
+// — can subscribe to the same broadcast feed without speaking
+// WebSocket.
 type RealtimeHub struct {
 	mu      sync.RWMutex
 	clients map[*wsClient]struct{}
+	sse     *sseRegistry
 }
 
 type wsClient struct {
@@ -42,6 +47,7 @@ type SubscribeRequest struct {
 func NewRealtimeHub() *RealtimeHub {
 	return &RealtimeHub{
 		clients: make(map[*wsClient]struct{}),
+		sse:     newSSERegistry(),
 	}
 }
 
@@ -148,7 +154,14 @@ func (h *RealtimeHub) readPump(c *wsClient) {
 	}
 }
 
-// Broadcast sends an event to all clients subscribed to the given channel+chain.
+// Broadcast sends an event to all clients subscribed to the given
+// channel+chain — both WebSocket (`HandleRealtime`) and SSE
+// (`HandleSSE`).
+//
+// WebSocket clients receive the JSON-encoded RealtimeMessage as a TEXT
+// frame. SSE clients receive the same payload wrapped in the SSE
+// `event: <type>\ndata: <json>\n\n` framing so the EventSource
+// onmessage / addEventListener('<type>', ...) handlers fire cleanly.
 func (h *RealtimeHub) Broadcast(eventType, chain string, data any) {
 	msg := RealtimeMessage{
 		Type:      eventType,
@@ -162,10 +175,8 @@ func (h *RealtimeHub) Broadcast(eventType, chain string, data any) {
 		return
 	}
 
-	// Match: exact channel, channel:chain, or unscoped channel
+	// WebSocket subscribers (existing path).
 	h.mu.RLock()
-	defer h.mu.RUnlock()
-
 	for client := range h.clients {
 		client.mu.Lock()
 		match := client.subs[eventType] || client.subs[eventType+":"+chain]
@@ -174,6 +185,14 @@ func (h *RealtimeHub) Broadcast(eventType, chain string, data any) {
 		if match {
 			client.sendRaw(encoded)
 		}
+	}
+	h.mu.RUnlock()
+
+	// SSE subscribers — wrap in SSE framing once, fan out cheaply.
+	if h.sse != nil {
+		framed := append([]byte("event: "+eventType+"\ndata: "), encoded...)
+		framed = append(framed, '\n', '\n')
+		h.sse.fanout(eventType, chain, framed)
 	}
 }
 

--- a/realtime_sse.go
+++ b/realtime_sse.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// SSE endpoints — Server-Sent Events at the URLs the bundled Vite SPA
+// expects (/blocks, /transactions, /token-transfers, /internal-txs,
+// /tokens, /gas-tracker, /stats, /validators).
+//
+// Why this exists (2026-05-21):
+//
+// The SPA opens EventSource against `${window.location.origin}/<channel>`
+// expecting `text/event-stream`. The Go backend previously had no
+// handler for those paths, so every request fell through to the SPA's
+// own static fallback (`handleSPA` → index.html), returning
+// `text/html`. Browser console then logged:
+//
+//     EventSource's response has a MIME type ("text/html") that is not
+//     "text/event-stream". Aborting the connection.
+//
+// …for every channel, on every page load. PR #4 silenced the HEAD
+// pre-flight (so the SPA cleanly disabled itself). This file goes the
+// other direction: make the SSE endpoints REAL, so the SPA opens them,
+// gets a proper `text/event-stream` reply, stays connected, and
+// receives broadcasts.
+//
+// Wire shape:
+//   - GET  /blocks                      → SSE for hub channel "blocks"
+//   - GET  /transactions                → SSE for hub channel "transactions"
+//   - GET  /token-transfers             → SSE for hub channel "token_transfers"
+//   - GET  /internal-txs                → SSE for hub channel "internal_transactions"
+//   - GET  /tokens, /gas-tracker, /validators → SSE that stays open with
+//     keep-alive pings; no broadcasters yet (placeholder so the SPA
+//     channel doesn't show as broken)
+//   - GET  /stats                       → SSE that emits the hub.Stats()
+//     map every 5s — cheap server-side state, useful liveness signal
+//   - HEAD <any>                        → 200 + the same headers so the
+//     SPA pre-flight (`fetch(url, {method: HEAD}).then(r => r.ok)`)
+//     succeeds before opening EventSource.
+//
+// Each connected client gets its own bounded channel. Slow consumers
+// drop messages rather than back-pressure the hub; the SPA refreshes
+// stale state via REST on reconnect.
+
+// sseClient is a single SSE subscriber. One per connected browser per
+// channel (the SPA opens one EventSource per channel it wants to follow).
+type sseClient struct {
+	channel string        // hub event-type to receive ("blocks" / "transactions" / ...)
+	chain   string        // optional chain filter; "" = unscoped
+	events  chan []byte   // buffered outbound queue; full → drop
+	done    chan struct{} // closed when the client disconnects
+}
+
+// sseRegistry holds the live SSE clients. Kept separate from the
+// WebSocket client map so the existing readPump/writePump paths don't
+// need to learn a new client shape.
+type sseRegistry struct {
+	mu      sync.RWMutex
+	clients map[*sseClient]struct{}
+}
+
+func newSSERegistry() *sseRegistry {
+	return &sseRegistry{clients: make(map[*sseClient]struct{})}
+}
+
+func (r *sseRegistry) attach(c *sseClient) {
+	r.mu.Lock()
+	r.clients[c] = struct{}{}
+	r.mu.Unlock()
+}
+
+func (r *sseRegistry) detach(c *sseClient) {
+	r.mu.Lock()
+	delete(r.clients, c)
+	r.mu.Unlock()
+	close(c.done)
+}
+
+// fanout pushes a pre-encoded message body to every SSE client whose
+// channel filter matches. Called from RealtimeHub.Broadcast.
+//
+// Match policy mirrors the WebSocket subs lookup:
+//   - exact channel match (client.channel == eventType)
+//   - chain-scoped match (channel + ":" + chain) is checked too so a
+//     subscriber that filtered on "blocks:cchain" sees only cchain
+//     events even if the hub broadcasts blocks across multiple chains
+func (r *sseRegistry) fanout(eventType, chain string, body []byte) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for c := range r.clients {
+		if c.channel != eventType {
+			continue
+		}
+		if c.chain != "" && c.chain != chain {
+			continue
+		}
+		select {
+		case c.events <- body:
+		default:
+			// Slow consumer — drop this event rather than block.
+		}
+	}
+}
+
+// HandleSSE returns an http.HandlerFunc bound to a specific channel
+// name. main.go mounts one per path.
+func (h *RealtimeHub) HandleSSE(channel string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// SSE response headers — set BEFORE the HEAD short-circuit so
+		// the pre-flight sees them and the SPA's `u.ok` check passes
+		// (200 + text/event-stream → open EventSource).
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		// Tell nginx-style proxies not to buffer the stream; without
+		// this the first event can sit in a buffer for ~5s, defeating
+		// the whole point of SSE.
+		w.Header().Set("X-Accel-Buffering", "no")
+
+		// HEAD pre-flight from EventSource open. Standard HTTP requires
+		// HEAD to return the same headers as GET would, with no body.
+		// We've already set them above; just acknowledge and return.
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			// Should be impossible on Go's net/http; defensive.
+			http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+			return
+		}
+
+		// Subscribe to the registry. `chain` query param is optional;
+		// blank = no chain filter, see fanout()'s match policy.
+		client := &sseClient{
+			channel: channel,
+			chain:   strings.TrimSpace(r.URL.Query().Get("chain")),
+			events:  make(chan []byte, 64),
+			done:    make(chan struct{}),
+		}
+		h.sse.attach(client)
+		defer h.sse.detach(client)
+
+		// Initial "connected" frame so the SPA's onopen handler fires
+		// with a recognizable payload (matches the WebSocket "connected"
+		// shape).
+		writeSSE(w, flusher, "connected", []byte(`{}`))
+
+		// Keep-alive ticker. Comment lines (`: ping`) don't fire the
+		// EventSource onmessage handler but keep the TCP/TLS connection
+		// alive through middleboxes that idle-timeout at 30s.
+		keepAlive := time.NewTicker(30 * time.Second)
+		defer keepAlive.Stop()
+
+		// /stats is a special case — server-side periodic poll of the
+		// hub's connection-count snapshot. Useful liveness signal even
+		// when no hub broadcasts have been wired up yet.
+		var statsTicker *time.Ticker
+		if channel == "stats" {
+			statsTicker = time.NewTicker(5 * time.Second)
+			defer statsTicker.Stop()
+		}
+
+		ctx := r.Context()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-client.done:
+				return
+			case <-keepAlive.C:
+				if _, err := w.Write([]byte(": ping\n\n")); err != nil {
+					return
+				}
+				flusher.Flush()
+			case msg := <-client.events:
+				// Broadcast messages are already JSON-encoded by the
+				// hub; we just prefix with the SSE framing.
+				if _, err := w.Write(msg); err != nil {
+					return
+				}
+				flusher.Flush()
+			default:
+				if statsTicker != nil {
+					select {
+					case <-statsTicker.C:
+						// Synthesize a stats event from the hub.
+						stats := fmt.Sprintf(
+							`{"connections":%d,"subscriptions":%d}`,
+							len(h.clients), len(h.sse.clients),
+						)
+						writeSSE(w, flusher, "stats", []byte(stats))
+						continue
+					default:
+					}
+				}
+				time.Sleep(50 * time.Millisecond)
+			}
+		}
+	}
+}
+
+// writeSSE emits one SSE event frame:
+//
+//	event: <name>
+//	data: <payload>
+//	(blank line)
+//
+// Per the SSE spec a frame ends with `\n\n`. Browsers tolerate `\r\n`
+// too but `\n` is the canonical form Go's net/http uses elsewhere.
+func writeSSE(w http.ResponseWriter, flusher http.Flusher, event string, payload []byte) {
+	fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, payload)
+	flusher.Flush()
+}


### PR DESCRIPTION
Adds Server-Sent Events handlers at the URLs the bundled Vite SPA opens EventSource on.

`RealtimeHub.Broadcast` now fans out to both WebSocket and SSE clients. HEAD returns 200+text/event-stream so the SPA pre-flight passes. Each SSE client has a 64-deep bounded queue with drop-on-full semantics.

See commit message for full background.