### PR TITLE
feat(realtime): add /v1/base/realtime multiplexed SSE channel

### DIFF
--- a/main.go
+++ b/main.go
@@ -146,6 +146,13 @@ func main() {
 		json.NewEncoder(w).Encode(registry.hub.Stats())
 	})
 
+	// /v1/base/realtime — multiplexed SSE channel the bundled SPA opens.
+	// One stream carries every broadcast in a JSON envelope `{event, chain, data}`
+	// that the SPA routes off via its handler map. See realtime_sse.go.
+	muxRealtimeSSE := registry.hub.HandleMultiplexedSSE()
+	mux.HandleFunc("GET /v1/base/realtime", muxRealtimeSSE)
+	mux.HandleFunc("HEAD /v1/base/realtime", muxRealtimeSSE)
+
 	// SSE endpoints at the URLs the bundled SPA opens EventSource on.
 	// See realtime_sse.go for the channel mapping + the back-story on
 	// why each path needs its own handler. Registering HEAD + GET

--- a/realtime.go
+++ b/realtime.go
@@ -189,10 +189,29 @@ func (h *RealtimeHub) Broadcast(eventType, chain string, data any) {
 	h.mu.RUnlock()
 
 	// SSE subscribers — wrap in SSE framing once, fan out cheaply.
+	//
+	// Two shapes, built up-front so fanout() is allocation-free:
+	//   - perChannel: `event: <type>\ndata: <RealtimeMessage JSON>\n\n`
+	//     for the per-channel /blocks /transactions /etc. endpoints.
+	//   - wildcard:   `data: {"event":<type>,"chain":<slug>,"data":<RealtimeMessage.Data JSON>}\n\n`
+	//     for the multiplexed /v1/base/realtime endpoint the SPA opens.
+	//     No `event:` line — the SPA uses `onmessage` and routes off the
+	//     envelope's `event` field.
 	if h.sse != nil {
-		framed := append([]byte("event: "+eventType+"\ndata: "), encoded...)
-		framed = append(framed, '\n', '\n')
-		h.sse.fanout(eventType, chain, framed)
+		perChannel := append([]byte("event: "+eventType+"\ndata: "), encoded...)
+		perChannel = append(perChannel, '\n', '\n')
+
+		envBody, err := json.Marshal(struct {
+			Event string `json:"event"`
+			Chain string `json:"chain,omitempty"`
+			Data  any    `json:"data,omitempty"`
+		}{Event: eventType, Chain: chain, Data: data})
+		var wildcard []byte
+		if err == nil {
+			wildcard = append([]byte("data: "), envBody...)
+			wildcard = append(wildcard, '\n', '\n')
+		}
+		h.sse.fanout(eventType, chain, perChannel, wildcard)
 	}
 }
 

--- a/realtime_sse.go
+++ b/realtime_sse.go
@@ -89,18 +89,32 @@ func (r *sseRegistry) detach(c *sseClient) {
 //   - chain-scoped match (channel + ":" + chain) is checked too so a
 //     subscriber that filtered on "blocks:cchain" sees only cchain
 //     events even if the hub broadcasts blocks across multiple chains
-func (r *sseRegistry) fanout(eventType, chain string, body []byte) {
+//   - wildcard (`*`) — clients attached by HandleMultiplexedSSE receive
+//     every event, but in a different envelope: SSE `data:` carries a
+//     JSON `{event, chain, data}` object the SPA can route off of. The
+//     wildcard `body` is built here; per-channel clients keep using the
+//     prebuilt per-channel framing from Broadcast for cheap reuse.
+func (r *sseRegistry) fanout(eventType, chain string, body []byte, wildcardEnvelope []byte) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	for c := range r.clients {
-		if c.channel != eventType {
+		var payload []byte
+		switch {
+		case c.channel == "*":
+			payload = wildcardEnvelope
+		case c.channel == eventType:
+			payload = body
+		default:
 			continue
 		}
 		if c.chain != "" && c.chain != chain {
 			continue
 		}
+		if payload == nil {
+			continue
+		}
 		select {
-		case c.events <- body:
+		case c.events <- payload:
 		default:
 			// Slow consumer — drop this event rather than block.
 		}
@@ -218,4 +232,81 @@ func (h *RealtimeHub) HandleSSE(channel string) http.HandlerFunc {
 func writeSSE(w http.ResponseWriter, flusher http.Flusher, event string, payload []byte) {
 	fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, payload)
 	flusher.Flush()
+}
+
+// HandleMultiplexedSSE returns an http.HandlerFunc that fans EVERY hub
+// broadcast into a single SSE stream, wrapping each event in a JSON
+// envelope `{"event":"<channel>","chain":"<slug>","data":<payload>}`.
+//
+// Wire shape the bundled SPA expects at `/v1/base/realtime` — it uses
+// `onmessage` (not event-typed listeners) and routes incoming frames
+// via a handler map keyed off `msg.event`:
+//
+//	client.es.onmessage = o => {
+//	    const c = JSON.parse(o.data);
+//	    const d = this.handlers.get(c.event);
+//	    if (d) for (const m of d) m(c.data);
+//	};
+//
+// So the SPA gets ONE EventSource and receives all event types over it,
+// instead of opening N parallel streams. This is the canonical realtime
+// channel — the per-channel /blocks /transactions /etc. endpoints stay
+// for backward compatibility and external consumers, but the SPA uses
+// only this one.
+func (h *RealtimeHub) HandleMultiplexedSSE() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("X-Accel-Buffering", "no")
+
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+			return
+		}
+
+		// Subscribe to ALL channels by registering a wildcard client.
+		// The empty `channel` means fanout() needs special handling — we
+		// use a sentinel "*" so we don't accidentally collide with a real
+		// channel called "" elsewhere.
+		client := &sseClient{
+			channel: "*",
+			chain:   strings.TrimSpace(r.URL.Query().Get("chain")),
+			events:  make(chan []byte, 128),
+			done:    make(chan struct{}),
+		}
+		h.sse.attach(client)
+		defer h.sse.detach(client)
+
+		writeSSE(w, flusher, "CONNECT", []byte(`{}`))
+
+		keepAlive := time.NewTicker(30 * time.Second)
+		defer keepAlive.Stop()
+
+		ctx := r.Context()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-client.done:
+				return
+			case <-keepAlive.C:
+				if _, err := w.Write([]byte(": ping\n\n")); err != nil {
+					return
+				}
+				flusher.Flush()
+			case msg := <-client.events:
+				if _, err := w.Write(msg); err != nil {
+					return
+				}
+				flusher.Flush()
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Summary
The bundled SPA opens a **single** EventSource at \`/v1/base/realtime\` and dispatches incoming frames off the \`msg.event\` field. Until this PR, that path returned 404 on HEAD (thanks to the explorer's HEAD-silencer for SPA-fallback paths) so the SPA's live client did \`disabled = true\` and never received any updates.

This adds the multiplexed endpoint:

| Path | Shape | Audience |
|---|---|---|
| \`GET /blocks\`, \`/transactions\`, …  | \`event:<type>\\ndata:<RealtimeMessage>\` | per-channel external consumers |
| **\`GET /v1/base/realtime\`** | \`data:{"event":<type>,"chain":<slug>,"data":<…>}\` | bundled SPA |

Implementation:
- \`HandleMultiplexedSSE()\` attaches a wildcard \`sseClient\` (\`channel = \"*\"\`)
- \`Broadcast()\` now builds **two** SSE payloads per event — per-channel framing as before, plus a JSON-envelope frame for wildcards
- \`sseRegistry.fanout()\` dispatches both based on \`client.channel\` (\`*\` → wildcard, \`blocks\` → per-channel)
- \`main.go\` mounts GET + HEAD for the new path

## Test plan
- [x] \`go build ./...\` + \`go vet\` + \`go test ./...\` clean
- [ ] After deploy: \`curl -sSN https://explorer.dev.satschel.com/v1/base/realtime\` returns \`event: CONNECT\\ndata: {}\` then keep-alives + multiplexed events when broadcasts fire
- [ ] SPA console shows no stuck connect retry loop