### PR TITLE
indexer: wire chains[].indexer.start_block + default devnet chainId

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,26 @@ ARG GRAPH_REPO=https://github.com/luxfi/graph.git
 ARG GRAPH_REF=main
 
 # ---- Stage 1: build the SPA ----
+#
+# Frontend chain knobs are build-time, not runtime: the Blockscout-fork
+# SPA reads NEXT_PUBLIC_* at `pnpm build` and bakes them into the
+# emitted JS. Default to the Liquid devnet shape; downstream rebuilds
+# override via --build-arg NETWORK_ID=… (etc.) for testnet/mainnet.
 FROM node:${NODE_VERSION}-alpine AS frontend
 ARG EXPLORE_REPO
 ARG EXPLORE_REF
+ARG NETWORK_ID=8675312
+ARG NETWORK_NAME="Liquid EVM"
+ARG NETWORK_CURRENCY_SYMBOL=LQDTY
 RUN apk add --no-cache git
 WORKDIR /app
 RUN git clone --depth=1 --branch=${EXPLORE_REF} ${EXPLORE_REPO} .
 ENV NEXT_PUBLIC_API_BASE_PATH=/v1/explorer
+ENV NEXT_PUBLIC_NETWORK_ID=${NETWORK_ID}
+ENV NEXT_PUBLIC_NETWORK_NAME=${NETWORK_NAME}
+ENV NEXT_PUBLIC_NETWORK_CURRENCY_NAME=${NETWORK_CURRENCY_SYMBOL}
+ENV NEXT_PUBLIC_NETWORK_CURRENCY_SYMBOL=${NETWORK_CURRENCY_SYMBOL}
+ENV NEXT_PUBLIC_NETWORK_CURRENCY_DECIMALS=18
 ENV NODE_OPTIONS=--max-old-space-size=8192
 RUN corepack enable && pnpm install --frozen-lockfile && pnpm build || true
 RUN mkdir -p /app/out && [ -f /app/out/index.html ] || \

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/luxfi/graph v1.2.0
-	github.com/luxfi/indexer v1.4.4
+	github.com/luxfi/indexer d5e65d4b50c127ce8982ef94f448dd17822448f7
 	github.com/luxfi/mdns v0.1.0
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	gopkg.in/yaml.v3 v3.0.1

--- a/supervisor.go
+++ b/supervisor.go
@@ -198,6 +198,7 @@ func (s *ChainSupervisor) runChain(ctx context.Context, cfg ChainConfig) {
 			RPCEndpoint:  cfg.RPC,
 			HTTPPort:     0,
 			PollInterval: poll,
+			StartBlock:   cfg.Indexer.StartBlock,
 		}, store)
 		if err != nil {
 			log.Printf("[%s] evm indexer: %v", cfg.Slug, err)


### PR DESCRIPTION
Two fixes for explorer-on-anvil-fork devnets. (1) Wire chains[].indexer.start_block through to evm.Config so the indexer skips historical backfill on mainnet-fork chains. (2) Default bundled SPA NETWORK_ID to 8675312 (was inheriting 8675311 from upstream luxfi/explore). Requires luxfi/indexer#8 (already merged, bumped via go mod edit).